### PR TITLE
benchmarks: bump body-parser to 2.3.0 in log-triage fixture

### DIFF
--- a/benchmarks/fixtures/log-triage/package-lock.json
+++ b/benchmarks/fixtures/log-triage/package-lock.json
@@ -30,8 +30,8 @@
       "integrity": "sha512-3Oix5Zb0EvIByLm5cIXNw3BzeaNHMS4rR4qd7Ogi5qZqV14SeuAIAr1mAc/gauRDccXR90zGNsETHcKSaRxR1w=="
     },
     "node_modules/body-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.1.1.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-YBZqtm21dZ+enjKfc/EtI5yAZMndJaaCm//KLsqjLoZFZkRVtVR06NsoIZ5jeVFKoaDFFKz5ZWcBbTsMNGmUkg=="
     },
     "node_modules/body-parser/node_modules/ms": {


### PR DESCRIPTION
Clears Dependabot alert [#34](https://github.com/V-Songbird/hush/security/dependabot/34) — GHSA-v422-hmwv-36x6 / CVE-2026-12590 (low severity).

`body-parser` < 2.3.0 silently disables request-body size enforcement when handed an invalid `limit` value. It reaches this repo only as a transitive dependency inside `benchmarks/fixtures/log-triage/package-lock.json`.

That lockfile is **synthetic fixture data** for the `log-triage` / `incident-followup` benchmark — it is never installed, and the task checks only assert on `ioredis@5.4.1` and the log contents. Bumping `body-parser` 2.1.1 → 2.3.0 clears the alert with no effect on the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)