### PR TITLE
docs: align hush presentation and evidence

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "description": "Trims command output, logs, and Claude's play-by-play before they pile up in the session, so long, noisy work stays quiet and readable. Install and forget — nothing to configure. Short questions with nothing to run cost a little more.",
+  "description": "Quieter sessions for Claude Code: less narration, shorter tool output and concise answers focused on the result.",
   "license": "MIT",
   "author": {
     "name": "Victor Villegas",

--- a/README.md
+++ b/README.md
@@ -23,26 +23,31 @@
 
 ## What is this?
 
-A coding assistant can finish the job and still leave you with a lot to read. Hush reduces that reading: less narration during the work, shorter command output, and a final answer focused on the result.
+You ask the assistant to fix a failing test. It reads files, runs commands and explains each step. By the time it finishes, the result is buried in the conversation. Hush reduces that reading.
 
-For a task such as fixing a failing test, the useful answer tells you what was fixed, whether the check passed and anything you still need to do. That is the kind of answer Hush aims for. This is an illustration of the goal, not a recorded result.
+It quiets routine narration, shortens noisy tool output and shapes the final answer around what changed, whether it worked and what comes next. The example illustrates the workflow; the measurements below describe recorded sessions.
 
 <p align="center"><img src="assets/mascot.svg" alt="Ember quiets the speech bubbles and log pile, then returns to calm typing." width="700"></p>
 
 ## Why you'd want it
 
-The point is to make the work easier to follow. Routine narration gets less space; the outcome, relevant detail and next action should remain. When shortened output is not enough, its reference gives you a way to inspect the full result where supported.
+- Read the result with less play-by-play.
+- Keep noisy command output from crowding the conversation.
+- Inspect retained full output when you need more detail.
+- Choose a writing voice that suits you.
 
 ## How it works
 
-There are two layers. Session controls reduce narration and tool-output noise. A writing style shapes the answer you read at the end. You can change the voice without changing the quiet-session controls.
+A writing style asks the assistant to stay quiet during routine work and finish with a short, useful answer. Session controls reinforce that behavior and trim selected tool results. Large outputs can be stored temporarily, with a reference for closer inspection. You can change the voice while keeping the session controls.
 
 ## What you can do
 
-- **Keep the default voice** for short, plain answers.
-- **Choose another voice** when you want a different tone.
-- **Describe a new voice** when the available styles do not fit.
-- **Inspect the full output** when a shortened command result needs closer reading.
+| You want to | Outcome |
+| --- | --- |
+| Keep the default voice | Short, plain answers focused on the result |
+| Choose another voice | A different tone with the session controls retained |
+| Describe a new voice | A custom style checked against Hush’s requirements |
+| Inspect shortened output | A reference to the retained full result where available |
 
 <!-- foundry:platform commands -->
 Use `/hush:pick-style` to choose a voice and `/hush:craft-style` to describe a new one. See the settings guide for disabling the session controls.
@@ -63,7 +68,7 @@ Start a new session to load the plugin.
 
 ## Good to know
 
-Correctness comes before silence. A short answer can still omit something you need, and quieter sessions do not always cost less. Check the result and next action, especially when trying a different voice.
+Correctness comes before silence. A short answer can omit a useful detail, and quieter sessions do not always cost less. Ask for depth when you need it, and check the result before acting.
 
 <!-- foundry:platform compatibility -->
 Full-output references point to temporary files. Disabling runtime controls and restoring the writing style are separate actions. See [Settings](docs/SETTINGS.md) for switches and platform-specific retention behavior.
@@ -74,15 +79,20 @@ Full-output references point to temporary files. Disabling runtime controls and 
 The comparison asks whether jobs were completed correctly, how often the assistant gave at most one update, and how long its final answers were. These observations do not guarantee the same behavior in your sessions.
 
 <!-- foundry:platform benchmarks -->
-<!-- foundry:evidence {"platform":"Claude","status":"measured","models":["Claude Opus 5"],"source":"docs/hush/validation/claude-readme-benchmark-source-2026-09-08.md","date":"unknown","revision":"13c24a9bd610a39740eb2816b54cc16b090978ed","dateReason":"The retained source excerpt does not state a run date.","reviewedAt":"2026-09-08"} -->
-| Model | Setup | Jobs right | At most one update | Final words |
+<!-- foundry:evidence {"platform":"Claude","status":"measured","models":["Claude Opus 5"],"source":"docs/hush/validation/claude-readme-benchmark-2026-09-10.md","date":"2026-09-01","reviewedAt":"2026-09-10"} -->
+| Model | Setup | Jobs right | At most one update | Median final prose words |
 | --- | --- | --- | --- | --- |
 | Claude Opus 5 | No plugin | 36/36 | 14/36 | 367 |
 | Claude Opus 5 | caveman | 36/36 | 31/36 | 151 |
 | Claude Opus 5 | hush | 36/36 | 36/36 | 69 |
 
-The final answer was shorter, but the next runnable action was retained in 94% of hush sessions versus 100% for the other setups. Three quiet jobs cost 1–10% more. These results describe the recorded Claude run.
-The retained source describes nine jobs and 36 sessions per setup. The run date is unknown; the source was reviewed on 2026-09-08. The settings guide states that published measurements used `HUSH_WRAP=1` and the shipped writing voice. [Retained benchmark source](https://github.com/V-Songbird/foundry/blob/main/docs/hush/validation/claude-readme-benchmark-source-2026-09-08.md).
+In this recorded comparison, Hush’s median final prose was 69 words against 367 without a plugin—about 81% shorter. Both setups passed all 36 task checks. Hush gave at most one mid-work update in every session.
+
+The readability check detected runnable content in 94% of Hush answers versus 100% for the other setups. Three quiet jobs cost 1–10% more. Detection is a text heuristic, not a check that the suggested action is correct or complete.
+
+Nine fixture jobs, four repetitions per setup; batch started September 1, 2026. The published source identifies Opus 5; the records retain the alias `opus` at medium effort. Measurements used the shipped voice and `HUSH_WRAP=1`. Word counts exclude fenced code. [Records, definitions and earlier comparisons](https://github.com/V-Songbird/foundry/blob/main/docs/hush/validation/claude-readme-benchmark-2026-09-10.md).
+
+Anthropic also reported approximately 55% lower cost on SWE-bench Verified with Sonnet 5 after combining medium effort with concise agent output. Hush already applies concise responses in Claude Code, alongside narration controls and tool-output trimming. That result measures Anthropic’s combined optimization, not Hush. [Read Anthropic’s findings](https://claude.com/blog/reducing-cost-and-improving-performance-with-claude-platform).
 <!-- /foundry:platform benchmarks -->
 
 <!-- foundry:hero -->

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,7 +1,10 @@
 # The numbers, in full
 
-Wins and losses. The front page carries the headline; this page carries everything, including the
-rows where hush comes out behind.
+The README uses the September 1, 2026 comparison, `rivalA-762f888b`: nine fixture jobs, four repetitions per setup, with the recorded `opus` alias at medium effort (identified as Opus 5 by the published source). Median final prose was 367 words without a plugin and 69 with Hush; both passed 36/36 task checks. The readability check detected runnable content in 94% of Hush answers versus 100% without a plugin. Three jobs cost 1–10% more.
+
+The tables below preserve the earlier August 30 comparisons: `rm320-99a236ff` (`opus`, 36 sessions per setup) and `sn320-a9885078` (`sonnet`, 18 per setup). Those batches did not record an explicit effort override, so the effective host default is unknown. They are separate runs, not additional repetitions of the README comparison.
+
+[Records, definitions and source reconciliation](https://github.com/V-Songbird/foundry/blob/main/docs/hush/validation/claude-readme-benchmark-2026-09-10.md). Raw output-token counts include all output billed by the API; prose word counts exclude fenced code. Readability word counts are medians; reading-ease and grade scores are heuristic averages, not a reader study.
 
 ← [Back to the README](../README.md)
 
@@ -23,8 +26,7 @@ checklist. **A short answer that breaks the job counts as a failure, not a win.*
 
 Every price is the real bill, read back from the API.
 
-Below: Claude Opus 5 at medium effort, four runs each way, plus the same nine jobs
-twice each way on Claude Sonnet. Failing-command trimming was on (`HUSH_WRAP=1`).
+Below: the earlier Opus and Sonnet comparisons described above. Failing-command trimming was on (`HUSH_WRAP=1`), with the shipped writing voice.
 
 ## Does it still work?
 
@@ -37,8 +39,7 @@ Nothing on this page was bought with a wrong answer.
 
 ## How quiet
 
-Every model opens a turn with a line about what it is about to do. No wording removes that for
-good, so the claim worth making is not *never speaks* — it is *speaks once, then nothing*.
+Some sessions still open with a line about what the assistant is about to do. These comparisons count both fully silent sessions and sessions with at most one update before the answer.
 
 | Claude Opus 5, 36 sessions each | no plugin | hush |
 | --- | --- | --- |
@@ -56,8 +57,7 @@ good, so the claim worth making is not *never speaks* — it is *speaks once, th
 | words of play-by-play, per session | 30.1 | **8.1** |
 
 The zero-word count is the softer of the two. It slides with how long a session runs — on the same
-build it reads near 100% on short jobs and drops away on the longest ones. The at-most-once count
-does not move with length.
+build it reads near 100% on short jobs and drops away on the longest ones. The at-most-once result held across these Opus sessions; it is not a guarantee for other workloads.
 
 ## How much it cuts
 
@@ -133,8 +133,7 @@ words a text uses.
 | no plugin | 167 | 16.5 | 11.3% | 61.8 | 8.7 |
 | **hush** | **82** | **10.9** | **8.4%** | **73.7** | **5.7** |
 
-Higher reading ease is easier. Lower grade level is easier. hush is three to four school grades
-easier than plain Claude Code on both models, in a sixth of the words on Opus.
+Higher reading ease and lower grade level indicate simpler text in these formulas. Hush scores three to four grades lower on these replies. That is a comparison of text features, not proof of comprehension or accessibility for a particular reader.
 
 ## Can you act on it without asking?
 
@@ -186,7 +185,7 @@ four other Sonnet jobs cost 7-8% more. On Opus the effect is smaller: two jobs, 
 what had happened.
 
 **The zero-word silence count drops as sessions get longer.** It is a real number and it is on this
-page, but it is not a promise. The at-most-one-message count is.
+page, but it is not a promise. The at-most-one-message count also describes these runs, not a guarantee.
 
 ## Run it yourself
 


### PR DESCRIPTION
Hush's README now follows Foundry's example-led presentation and separates its own fixture evidence from Anthropic's combined effort/output optimization. Word counts are labelled as medians, benchmark batches have their own provenance, and limitations remain beside the results. Plugin descriptions use the shared product voice.

Validation: paired README and navigation checks passed; retained benchmark hashes and metrics were checked; required local commit checks passed. No runtime behavior changed.

Foundry-README-Peer: #21@9fedc7255bdb0bd79ef8609788a5af6c59529783

