### PR TITLE
docs: align hush presentation and evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,31 @@
 
 ## What is this?
 
-A coding assistant can finish the job and still leave you with a lot to read. Hush reduces that reading: less narration during the work, shorter command output, and a final answer focused on the result.
+You ask the assistant to fix a failing test. It reads files, runs commands and explains each step. By the time it finishes, the result is buried in the conversation. Hush reduces that reading.
 
-For a task such as fixing a failing test, the useful answer tells you what was fixed, whether the check passed and anything you still need to do. That is the kind of answer Hush aims for. This is an illustration of the goal, not a recorded result.
+It quiets routine narration, shortens noisy tool output and shapes the final answer around what changed, whether it worked and what comes next. The example illustrates the workflow; the measurements below describe recorded sessions.
 
 <p align="center"><img src="assets/mascot.svg" alt="Ember quiets the speech bubbles and log pile, then returns to calm typing." width="700"></p>
 
 ## Why you'd want it
 
-The point is to make the work easier to follow. Routine narration gets less space; the outcome, relevant detail and next action should remain. When shortened output is not enough, its reference gives you a way to inspect the full result where supported.
+- Read the result with less play-by-play.
+- Keep noisy command output from crowding the conversation.
+- Inspect retained full output when you need more detail.
+- Choose a writing voice that suits you.
 
 ## How it works
 
-There are two layers. Session controls reduce narration and tool-output noise. A writing style shapes the answer you read at the end. You can change the voice without changing the quiet-session controls.
+A writing style asks the assistant to stay quiet during routine work and finish with a short, useful answer. Session controls reinforce that behavior and trim selected tool results. Large outputs can be stored temporarily, with a reference for closer inspection. You can change the voice while keeping the session controls.
 
 ## What you can do
 
-- **Keep the default voice** for short, plain answers.
-- **Choose another voice** when you want a different tone.
-- **Describe a new voice** when the available styles do not fit.
-- **Inspect the full output** when a shortened command result needs closer reading.
+| You want to | Outcome |
+| --- | --- |
+| Keep the default voice | Short, plain answers focused on the result |
+| Choose another voice | A different tone with the session controls retained |
+| Describe a new voice | A custom style checked against Hush’s requirements |
+| Inspect shortened output | A reference to the retained full result where available |
 
 <!-- foundry:platform commands -->
 No native Codex commands or skills are available yet.
@@ -56,7 +61,7 @@ Hush for Codex is in development. This branch has no installable plugin package 
 
 ## Good to know
 
-Correctness comes before silence. A short answer can still omit something you need, and quieter sessions do not always cost less. Check the result and next action, especially when trying a different voice.
+Correctness comes before silence. A short answer can omit a useful detail, and quieter sessions do not always cost less. Ask for depth when you need it, and check the result before acting.
 
 <!-- foundry:platform compatibility -->
 The shared description states the product’s purpose. It does not establish that these behaviors exist in the unfinished Codex edition.
@@ -68,7 +73,7 @@ The comparison asks whether jobs were completed correctly, how often the assista
 
 <!-- foundry:platform benchmarks -->
 <!-- foundry:evidence {"platform":"Codex","status":"pending","reason":"No installable Codex edition or paired benchmark yet."} -->
-| Model | Setup | Jobs right | At most one update | Final words |
+| Model | Setup | Jobs right | At most one update | Median final prose words |
 | --- | --- | --- | --- | --- |
 | Not measured | Without plugin | Not measured | Not measured | Not measured |
 | Not measured | hush | Not measured | Not measured | Not measured |


### PR DESCRIPTION
Hush's README now follows Foundry's example-led presentation and separates its own fixture evidence from Anthropic's combined effort/output optimization. Word counts are labelled as medians, benchmark batches have their own provenance, and limitations remain beside the results. Plugin descriptions use the shared product voice.

Validation: paired README and navigation checks passed; retained benchmark hashes and metrics were checked; required local commit checks passed. No runtime behavior changed.

Foundry-README-Peer: #20@e5a4ce21bc778205f7288675636abc6f8ad802eb

